### PR TITLE
fix: update load_data_csv path and suppress per-cell debug bottleneck

### DIFF
--- a/snakemake/scripts/aggregate_sources.py
+++ b/snakemake/scripts/aggregate_sources.py
@@ -59,7 +59,7 @@ def _get_sample_index_map(batch_file: h5py.File, source_group: h5py.Group) -> di
     sample_index_map = {}
     for cell_idx in range(n_cells):
         cell_inchi_key = _get_cell_label(batch_file, cell_idx, inchi_key_label_idx)
-        module_logger.debug(f"Cell inchi key: {cell_inchi_key}")
+        # module_logger.debug(f"Cell inchi key: {cell_inchi_key}")  # bottleneck
         sample_id = _get_cell_label(batch_file, cell_idx, id_label_idx)
         try:
             inchi_group = _get_group(cell_inchi_key, source_group)

--- a/snakemake/scripts/dl.py
+++ b/snakemake/scripts/dl.py
@@ -101,7 +101,7 @@ class JumpConfig:
 
         self.loaddata_formatter = (
             "s3://cellpainting-gallery/cpg0016-jump/"
-            "{Metadata_Source}/workspace/load_data_csv_orig/"
+            "{Metadata_Source}/workspace/load_data_csv/"
             "{Metadata_Batch}/{Metadata_Plate}/load_data_with_illum.parquet"
         )
 
@@ -552,7 +552,7 @@ class JumpDl(JumpMeta):
     def _get_parquet_url(source: str, batch: str, plate: str) -> pl.Path:
         url = (
             f"s3://cellpainting-gallery/cpg0016-jump/{source}/"
-            f"workspace/load_data_csv_orig/{batch}/{plate}/"
+            f"workspace/load_data_csv/{batch}/{plate}/"
             f"load_data_with_illum.parquet"
         )
         return pl.Path(url)


### PR DESCRIPTION
## Summary

- **`dl.py`**: Replace `load_data_csv_orig` with `load_data_csv` in both `JumpConfig.loaddata_formatter` and `JumpDl._get_parquet_url`. The `_orig` path no longer exists on S3, causing downloads to fail.
- **`aggregate_sources.py`**: Comment out the per-cell InChI key debug log in `_get_sample_index_map`. This log fires once per cell in a tight loop over all cells in a plate (~20k–300k cells) and was identified as a significant performance bottleneck.