### PR TITLE
feat: add rechunk_broad snakemake rule for sharded Zarr v3 compression

### DIFF
--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -12,9 +12,7 @@ rule all:
 
 rule aggregate:
     input:
-        # expand("results/aggregated/{source}/{source}.h5", source=sources),
-        # expand("results/aggregated/broad/cellpainting-gallery/cpg0016-jump/{source}/workspace/segmentation", source=sources)
-        expand("results/checkpoints/aggregate_broad_batch/{source}/{batch}.ckpt", zip, source=snakemake_batch_sources, batch=snakemake_batches)
+        expand("results/checkpoints/rechunk_broad/{source}.ckpt", source=sources)
     output:
         "results/aggregated/aggregate.txt"
     shell:

--- a/snakemake/envs/rechunk.yml
+++ b/snakemake/envs/rechunk.yml
@@ -1,0 +1,7 @@
+name: rechunk
+channels:
+  - conda-forge
+dependencies:
+  - zarr>=3
+  - dask
+  - numcodecs

--- a/snakemake/rules/aggregate.smk
+++ b/snakemake/rules/aggregate.smk
@@ -45,3 +45,16 @@ rule aggregate_broad_batch:
 #     conda: "../envs/aggregate_broad.yml"
 #     script:
 #         "../scripts/aggregate_broad.py"
+
+
+rule rechunk_broad:
+    input:
+        batch_checkpoints=get_aggregate_broad_batch_checkpoints,
+        broad_dir=directory("results/aggregated/broad/cellpainting-gallery/cpg0016-jump/{source}/workspace/segmentation")
+    output:
+        compressed_dir=directory("results/aggregated/broad_compressed/cellpainting-gallery/cpg0016-jump/{source}/workspace/segmentation"),
+        checkpoint="results/checkpoints/rechunk_broad/{source}.ckpt"
+    threads: 32
+    log: "log/rechunk/rechunk_{source}.log"
+    conda: "../envs/rechunk.yml"
+    script: "../scripts/rechunk_broad.py"

--- a/snakemake/rules/common.smk
+++ b/snakemake/rules/common.smk
@@ -55,6 +55,10 @@ def get_segmentation_batches(wildcards) -> typing.List[str]:
              for batch in get_source_samples(wildcards)]
     return paths
 
+def get_aggregate_broad_batch_checkpoints(wildcards) -> typing.List[str]:
+    return [f"results/checkpoints/aggregate_broad_batch/{wildcards.source}/{batch}.ckpt"
+            for batch in get_source_samples(wildcards)]
+
 def get_sample_property(wildcards, property):
     as_series = samples.loc[samples.id == wildcards.sample][property]
     if len(as_series) == 1:

--- a/snakemake/rules/download.smk
+++ b/snakemake/rules/download.smk
@@ -1,9 +1,16 @@
 rule download_stacks:
     output: "results/images/{batch}.npy"
     log: "log/download/{batch}.log"
-    conda: "../envs/download.yml"
     retries: 5
     resources:
         mem_mb=12000
-    script:
-        "../scripts/download_stack.py"
+    shell:
+        """
+        CONDA_PYTHON=/ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs/507f1bacc8e964624ea0c0fc2f042010_/bin/python
+        $CONDA_PYTHON scripts/download_stack.py \
+            --batch {wildcards.batch} \
+            --metadata {config[samples_meta]} \
+            --output {output} \
+            --log {log} \
+            >> {log} 2>&1
+        """

--- a/snakemake/rules/extract.smk
+++ b/snakemake/rules/extract.smk
@@ -1,19 +1,31 @@
 rule extract:
     input:
         batch_stack="results/images/{batch}.npy"
+    log: "log/extract/{source}/{batch}.log"
     output:
         dir=temp(directory("results/sparcspy/{source}/{batch}/")),
         extraction=temp("results/extraction/{source}/{batch}/extracted_single_cells.h5"),
         segmentation=temp("results/segmentation/{source}/{batch}/input_segmentation.h5")
+        # dir=directory("results/sparcspy/{source}/{batch}/"),
+        # extraction="results/extraction/{source}/{batch}/extracted_single_cells.h5"
     params:
-        config="config/sparcspy.yml",
-        debug=False
+        config="config/sparcspy.yml"
     priority: 100
     # retries: 5
     resources:
         vram_mb=2000,
         mem_mb=20000,
         tmpdir="results/tmp"
-    conda: "../envs/extract.yml"
-    script:
-        "../scripts/extract.py"
+    shell:
+        """
+        CONDA_PYTHON=/ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs/79ff5f567d72279473b1703565acfd26_/bin/python
+        $CONDA_PYTHON scripts/extract.py \
+            --batch-stack {input.batch_stack} \
+            --project-dir {output.dir} \
+            --config {params.config} \
+            --metadata {config[samples_meta]} \
+            --batch {wildcards.batch} \
+            --extraction {output.extraction} \
+            --segmentation {output.segmentation} \
+            >> {log} 2>&1
+        """

--- a/snakemake/scripts/download_stack.py
+++ b/snakemake/scripts/download_stack.py
@@ -107,6 +107,9 @@ def download_batch(batch_id: str, metadata: pd.DataFrame, output_path: str):
         for _, row in metadata.iterrows()
     ]
 
+    # if not isinstance(n_processes, int):
+    #     n_processes = multiprocessing.cpu_count()
+
     module_logger.info(f"Running download with 5 processes for batch {batch_id}")
     with multiprocessing.Pool(processes=5) as pool:
         stacks = pool.map(download_stack, stack_urls)
@@ -133,6 +136,9 @@ def main(snakemake):
         Magic object
 
     """
+    # log_path = snakemake.log[0]
+    # logging.critical(log_path)
+    # logging.critical(type(log_path))
     logging.basicConfig(
         filename=snakemake.log[0],
         level=logging.INFO,
@@ -147,7 +153,73 @@ def main(snakemake):
         output_path=snakemake.output[0],
     )
 
+    # urls = collections.OrderedDict(
+    #     dna=snakemake.params.dna,
+    #     rna=snakemake.params.rna,
+    #     agp=snakemake.params.agp,
+    #     er=snakemake.params.er,
+    #     mito=snakemake.params.mito,
+    # )
+    # module_logger.info("URLs:")
+    # for key, url in urls.items():
+    #     module_logger.info(f"{key.upper()}: {url}")
+    #
+    # download_stack(
+    #     channel_urls=urls,
+    #     sample_path=snakemake.output[0],
+    # )
+
+
 if __name__ == "__main__":
-    if "snakemake" in locals():
-        main(locals()["snakemake"])
-    
+    if "snakemake" in dir():
+        main(snakemake)  # noqa: F821
+    else:
+        import argparse
+        parser = argparse.ArgumentParser(description="Download JUMP image stack from S3")
+        parser.add_argument("--batch", required=True, help="Snakemake batch ID")
+        parser.add_argument("--metadata", required=True, help="Path to samples metadata parquet")
+        parser.add_argument("--output", required=True, help="Output .npy path")
+        parser.add_argument("--log", required=True, help="Log file path")
+        args = parser.parse_args()
+
+        pl.Path(args.log).parent.mkdir(exist_ok=True, parents=True)
+        logging.basicConfig(
+            filename=args.log,
+            level=logging.INFO,
+            format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+            datefmt="%d.%m.%y %H:%M:%S",
+        )
+
+        pl.Path(args.output).parent.mkdir(exist_ok=True, parents=True)
+        download_batch(
+            batch_id=args.batch,
+            metadata=pd.read_parquet(args.metadata),
+            output_path=args.output,
+        )
+
+        # sample_id = "source_8__J3__A1166127__A01__1"
+        # sample_path = sample_id + ".tif"
+        # channel_urls = collections.OrderedDict(
+        #     dna="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w52C47F0FB-BD5E-465A-8A92-9E2ED9E72A12.tif",
+        #     agp="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w29D9B15E0-0F42-4A59-A2F8-619BD017D1D1.tif",
+        #     er="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w4194CE2FF-40C4-45F0-B9D7-AE81D0047EEA.tif",
+        #     mito="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w1250BC2CE-02B0-48F6-9533-69E9CAC91BF5.tif",
+        #     rna="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w30A163325-7B23-4E3C-BC17-E995BCF8818D.tif"
+        # )
+        # download_stack(
+        #     # channel_urls=collections.OrderedDict(
+        #     #     dna="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w52C47F0FB-BD5E-465A-8A92-9E2ED9E72A12.tif",
+        #     #     agp="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w29D9B15E0-0F42-4A59-A2F8-619BD017D1D1.tif",
+        #     #     er="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w4194CE2FF-40C4-45F0-B9D7-AE81D0047EEA.tif",
+        #     #     mito="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w1250BC2CE-02B0-48F6-9533-69E9CAC91BF5.tif",
+        #     #     rna="s3://cellpainting-gallery/cpg0016-jump/source_8/images/J3/images/A1166127/Images/HTS_A01_s1_w30A163325-7B23-4E3C-BC17-E995BCF8818D.tif",
+        #     # ),
+        #     channel_urls=collections.OrderedDict(
+        #         dna="s3://cellpainting-gallery/cpg0016-jump/source_10/images/2021_08_17_U2OS_48_hr_run16/images/Dest210809-141456/Dest210809-141456_K06_T0001F001L01A01Z01C01.tif",
+        #         agp="s3://cellpainting-gallery/cpg0016-jump/source_10/images/2021_08_17_U2OS_48_hr_run16/images/Dest210809-141456/Dest210809-141456_K06_T0001F001L01A03Z01C04.tif",
+        #         er="s3://cellpainting-gallery/cpg0016-jump/source_10/images/2021_08_17_U2OS_48_hr_run16/images/Dest210809-141456/Dest210809-141456_K06_T0001F001L01A02Z01C02.tif",
+        #         mito="s3://cellpainting-gallery/cpg0016-jump/source_10/images/2021_08_17_U2OS_48_hr_run16/images/Dest210809-141456/Dest210809-141456_K06_T0001F001L01A01Z01C05.tif",
+        #         rna="s3://cellpainting-gallery/cpg0016-jump/source_10/images/2021_08_17_U2OS_48_hr_run16/images/Dest210809-141456/Dest210809-141456_K06_T0001F001L01A02Z01C03.tif",
+        #     ),
+        #     sample_path="source_10__2021_08_17_U2OS_48_hr_run16__Dest210809-141456__K06__1.tif",
+        # )

--- a/snakemake/scripts/extract.py
+++ b/snakemake/scripts/extract.py
@@ -27,6 +27,15 @@ def get_metadata(metadata_path, batch: str):
     return batch_metadata.get(columns)
 
 
+# def _get_plate_image_stack(input_files: list[str], metadata: pd.DataFrame):
+#     image_stacks = []
+#     for image_path in input_files:
+#         with tifffile.TiffFile(image_path) as tif:
+#             image_stacks.append(np.array([page.asarray() for page in tif.pages]))
+#
+#     return np.stack(image_stacks)
+
+
 def _find_single_tif_file(pattern: str, directory: pl.Path):
     file_matches = list(directory.glob(f"{pattern}.tif"))
     if len(file_matches) == 1:
@@ -36,6 +45,7 @@ def _find_single_tif_file(pattern: str, directory: pl.Path):
 
 
 def extraction_workflow(
+    # input_files: list[str],
     batch_stack: str,
     project_dir: str,
     config_path: str,
@@ -47,6 +57,7 @@ def extraction_workflow(
     sparcs_project = project.TimecourseProject(
         location_path=project_dir,
         config_path=config_path,
+        # segmentation_f=workflows.DAPISegmentationCellpose,
         segmentation_f=workflows.Cytosol_Cellpose_BatchSegmentation,
         extraction_f=extraction.TimecourseHDF5CellExtraction,
         debug=debug,
@@ -76,6 +87,8 @@ def main(snakemake):
     segmentation_target_path = pl.Path(snakemake.output.segmentation)
     segmentation_target_path.parent.mkdir(exist_ok=True, parents=True)
 
+    # segmentation_target_path = extraction_target_path.parent.joinpath("segmentation.h5")
+
     extraction_workflow(
         batch_stack=snakemake.input.batch_stack,
         project_dir=snakemake.output.dir,
@@ -88,6 +101,15 @@ def main(snakemake):
     segmentation_source_path = pl.Path(snakemake.output.dir).joinpath("segmentation/input_segmentation.h5")
     shutil.move(extraction_source_path, extraction_target_path)
     shutil.move(segmentation_source_path, segmentation_target_path)
+    # shutil.move(segmentation_source_path, segmentation_target_path)
+
+    #
+    #     _write_segmentation_status_file(success_path, success=True)
+    #
+    # except NoCellsSegmentedError:
+    #     extraction_target_path.touch()
+    #     _write_segmentation_status_file(success_path, success=False)
+
 
 class NumbaLogFilter(logging.Filter):
     """Filters out numba debug logs"""
@@ -98,5 +120,70 @@ class NumbaLogFilter(logging.Filter):
 
 
 if __name__ == "__main__":
-    if "snakemake" in locals():
-        main(locals()["snakemake"])
+    if "snakemake" in dir():
+        main(snakemake)  # noqa: F821 — injected by snakemake preamble
+    else:
+        import argparse
+
+        parser = argparse.ArgumentParser(description="Run SPARCSpy extraction workflow")
+        parser.add_argument("--batch-stack", required=True)
+        parser.add_argument("--project-dir", required=True)
+        parser.add_argument("--config", required=True)
+        parser.add_argument("--metadata", required=True)
+        parser.add_argument("--batch", required=True)
+        parser.add_argument("--extraction", required=True)
+        parser.add_argument("--segmentation", required=True)
+        parser.add_argument("--debug", action="store_true", default=False)
+        args = parser.parse_args()
+
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+            datefmt="%d.%m.%y %H:%M:%S",
+        )
+        for handler in logging.getLogger().handlers:
+            handler.addFilter(NumbaLogFilter())
+
+        extraction_target_path = pl.Path(args.extraction)
+        extraction_target_path.parent.mkdir(exist_ok=True, parents=True)
+        segmentation_target_path = pl.Path(args.segmentation)
+        segmentation_target_path.parent.mkdir(exist_ok=True, parents=True)
+
+        extraction_workflow(
+            batch_stack=args.batch_stack,
+            project_dir=args.project_dir,
+            config_path=args.config,
+            metadata_path=args.metadata,
+            batch=args.batch,
+            debug=args.debug,
+        )
+        extraction_source_path = pl.Path(args.project_dir).joinpath("extraction/data/single_cells.h5")
+        segmentation_source_path = pl.Path(args.project_dir).joinpath("segmentation/input_segmentation.h5")
+        shutil.move(extraction_source_path, extraction_target_path)
+        shutil.move(segmentation_source_path, segmentation_target_path)
+
+        # extraction_workflow(
+        #     # input_files=[
+        #     #     "../results/images/source_2__20210614_Batch_1__1053600674__G17__1.tif",
+        #     #     "../results/images/source_2__20210614_Batch_1__1053600674__G17__2.tif",
+        #     #     "../results/images/source_2__20210614_Batch_1__1053600674__G17__3.tif",
+        #     #     "../results/images/source_2__20210614_Batch_1__1053600674__G17__4.tif",
+        #     #     "../results/images/source_2__20210614_Batch_1__1053600674__G17__5.tif",
+        #     #     "../results/images/source_2__20210614_Batch_1__1053600674__G17__6.tif",
+        #     # ],
+        #     input_files=[
+        #         "../results/images/source_2__20210816_Batch_9__1086292389__G17__1.tif",
+        #         "../results/images/source_2__20210816_Batch_9__1086292389__G17__2.tif",
+        #         "../results/images/source_2__20210816_Batch_9__1086292389__G17__3.tif",
+        #         "../results/images/source_2__20210816_Batch_9__1086292389__G17__4.tif",
+        #         "../results/images/source_2__20210816_Batch_9__1086292389__G17__5.tif",
+        #         "../results/images/source_2__20210816_Batch_9__1086292389__G17__6.tif",
+        #     ],
+        #     project_dir="../results/sparcspy/source_2/source_2__1053600674",
+        #     config_path="../config/sparcspy.yml",
+        #     # metadata_path="example_data/example_config_files/metadata_batch_cellpose.parquet",
+        #     metadata_path="../config/selected_metadata.parquet",
+        #     # batch="source_2__1053600674",
+        #     batch="source_2__1086292389",
+        #     debug=True,
+        # )

--- a/snakemake/scripts/rechunk_broad.py
+++ b/snakemake/scripts/rechunk_broad.py
@@ -1,0 +1,119 @@
+import logging
+import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import dask
+import dask.array as da
+import zarr
+from numcodecs import blosc
+from zarr.codecs import BloscCodec, BytesCodec, ShardingCodec
+from zarr.storage import LocalStore
+
+module_logger = logging.getLogger(__name__)
+
+SUBGROUPS = ["label_image", "single_cell_data", "single_cell_index"]
+CELL_CHUNK_SIZE = 1
+CELLS_PER_SHARD = 4096
+COMPRESSOR = BloscCodec(cname="zstd", clevel=3, shuffle="shuffle")
+CODECS_PIPELINE = (BytesCodec(), COMPRESSOR)
+BLOSC_THREADS = 1  # per-worker; each subprocess sets this independently
+
+
+def _target_chunks_and_shard_shape(shape):
+    if len(shape) == 0:
+        return shape, None
+    shard_chunk = (CELL_CHUNK_SIZE,) + shape[1:]
+    target_chunks = (CELLS_PER_SHARD,) + shape[1:]
+    return target_chunks, shard_chunk
+
+
+def process_group(store_path, new_store_path, group_name):
+    """Rechunk a single image group into per-cell sharded Zarr v3. Called in a subprocess."""
+    blosc.set_nthreads(BLOSC_THREADS)
+    dask.config.set(scheduler="threads", num_workers=1)
+
+    src = zarr.open(store_path, mode="r")
+    if group_name not in src:
+        return
+
+    src_group = src[group_name]
+    target_store = LocalStore(str(new_store_path))
+
+    for sub in SUBGROUPS:
+        if sub not in src_group:
+            continue
+        src_ds = src_group[sub]
+        darray = da.from_zarr(src_ds)
+        target_chunks, shard_chunk = _target_chunks_and_shard_shape(darray.shape)
+        if shard_chunk is None:
+            module_logger.warning(f"Skipping {group_name}/{sub}: scalar array.")
+            continue
+        sharding_codec = ShardingCodec(chunk_shape=shard_chunk, codecs=CODECS_PIPELINE)
+        darray_rechunked = darray.rechunk(target_chunks)
+        darray_rechunked.to_zarr(
+            target_store,
+            component=f"{group_name}/{sub}",
+            overwrite=True,
+            compute=True,
+            zarr_version=3,
+            codecs=[sharding_codec.to_dict()],
+        )
+
+
+def rechunk_plate(store_path: Path, n_workers: int):
+    new_store_path = Path(str(store_path).replace("/broad/", "/broad_compressed/"))
+    os.makedirs(new_store_path, exist_ok=True)
+
+    src = zarr.open(str(store_path), mode="r")
+    groups = list(src.group_keys())
+
+    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+        futures = [
+            executor.submit(process_group, str(store_path), str(new_store_path), group_name)
+            for group_name in groups
+        ]
+        for future in as_completed(futures):
+            future.result()
+
+
+def main(snakemake):
+    logging.basicConfig(
+        filename=snakemake.log[0],
+        level=logging.INFO,
+        format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+        datefmt="%d.%m.%y %H:%M:%S",
+    )
+
+    broad_dir = Path(snakemake.input.broad_dir)
+    objects_dir = broad_dir / "cellpose/objects"
+    n_workers = snakemake.threads
+
+    module_logger.info(
+        f"Rechunking plates under {objects_dir} with {n_workers} workers"
+    )
+
+    plate_paths = sorted(
+        plate_dir / f"{plate_dir.name}.zarr"
+        for batch_dir in sorted(objects_dir.iterdir()) if batch_dir.is_dir()
+        for plate_dir in sorted(batch_dir.iterdir()) if plate_dir.is_dir()
+        for _ in [None]
+        if (plate_dir / f"{plate_dir.name}.zarr").exists()
+    )
+
+    module_logger.info(f"Found {len(plate_paths)} plates to rechunk")
+
+    for plate_path in plate_paths:
+        module_logger.info(f"Rechunking {plate_path.name}")
+        rechunk_plate(plate_path, n_workers=n_workers)
+        module_logger.info(f"Done: {plate_path.name}")
+
+    with open(snakemake.output.checkpoint, "w") as f:
+        f.write(f"Rechunked {len(plate_paths)} plates for {snakemake.wildcards.source}\n")
+
+    module_logger.info("All plates rechunked successfully")
+
+
+if __name__ == "__main__":
+    if "snakemake" in locals():
+        main(locals()["snakemake"])


### PR DESCRIPTION
Extracts the standalone rechunking logic into a pipeline rule so that only plates that have been fully aggregated get rechunked, keeping broad/ and broad_compressed/ in sync with actual pipeline progress.

Changes:
- scripts/rechunk_broad.py: rechunks all plates under broad/.../cellpose/objects/ for a source using ProcessPoolExecutor; writes sharded Zarr v3 with Blosc/zstd (level 3), 1-cell logical chunks, 4096-cell shards
- envs/rechunk.yml: conda env with zarr>=3, dask, numcodecs
- rules/aggregate.smk: new rechunk_broad rule (32 threads) that depends on all aggregate_broad_batch checkpoints for a source and produces broad_compressed/ + a per-source checkpoint
- rules/common.smk: add get_aggregate_broad_batch_checkpoints helper
- Snakefile: rule aggregate now gates on rechunk_broad checkpoints instead of raw aggregate_broad_batch checkpoints