### PR TITLE
Add tasks and lessons docs

### DIFF
--- a/scripts/check_progress.sh
+++ b/scripts/check_progress.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Check segmentation pipeline progress for all sources.
+# Counts output files on disk (not log messages) to avoid NFS cache lag.
+
+SNAKEMAKE_BASE=/ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake
+PYTHON=/home/icb/tim.treis/miniforge3/bin/python
+
+printf "%-10s %-8s %-8s %-8s %-8s %-12s\n" "Source" "Extracted" "Total" "Pct%" "Images" "Broad_agg"
+printf "%-10s %-8s %-8s %-8s %-8s %-12s\n" "------" "---------" "-----" "----" "------" "---------"
+
+for src in 02 03 04 05 06 07 08 09 10 11 13; do
+  src_num=${src#0}  # strip leading zero for directory names (source_3 not source_03)
+  BASE=$SNAKEMAKE_BASE/final_source${src}/snakemake
+
+  [ -d "$BASE" ] || continue
+
+  extracted=$(ls "$BASE/results/extraction/source_${src_num}/" 2>/dev/null | wc -l)
+  images=$(ls "$BASE/results/images/" 2>/dev/null | wc -l)
+  broad=$(ls "$BASE/results/aggregated/broad/" 2>/dev/null | wc -l)
+
+  total=$($PYTHON -c \
+    "import pandas as pd; df=pd.read_parquet('$BASE/config/selected_metadata.parquet'); print(df['snakemake_batch'].nunique())" \
+    2>/dev/null || echo "?")
+
+  if [ "$total" = "?" ] || [ "$total" = "0" ]; then
+    pct="?"
+  else
+    pct=$(python3 -c "print(f'{$extracted/$total*100:.0f}%')" 2>/dev/null || echo "?")
+  fi
+
+  final=""
+  [ -f "$BASE/results/aggregated/aggregate.txt" ] && final=" [DONE]"
+
+  printf "%-10s %-8s %-8s %-8s %-8s %-12s%s\n" \
+    "source${src}" "$extracted" "$total" "$pct" "$images" "$broad" "$final"
+done
+
+echo ""
+echo "Running snakemake processes:"
+ps aux | grep "snakemake.*profile" | grep -v grep | awk '{print "  PID "$2" ("$11")"}' || echo "  none"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,29 +1,169 @@
 # Lessons Learned
 
-## System snakemake (v7) has broken pulp dependency
-The system-installed snakemake 7.32.4 at `~/.local/bin/snakemake` fails with `AttributeError: module 'pulp' has no attribute 'list_solvers'` due to PuLP 2.9 removing that function. Fix: use pixi to install snakemake 8 (as source_03 does). Don't try to downgrade PuLP — the system has multiple Python versions (3.9 for snakemake, 3.12 for pip) making it messy.
-**Why:** Lost 20 min debugging this. Use pixi for snakemake everywhere.
+## conda activation fails in pixi task subprocesses
 
-## pixi run needs cwd to contain pixi.toml
-`pixi run` looks for `pixi.toml` in the current working directory. Use `--manifest-path` if running from elsewhere, or ensure the shell cd's first. In Claude Code, bash tool resets cwd between calls unless cd is chained in the same command.
-**Why:** Multiple failed pipeline launch attempts due to wrong cwd.
+In a pixi task that sets `env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" }`, snakemake's `conda:` + `script:` directive silently fails to activate the conda env. `source activate` runs but doesn't actually prepend the env to PATH — `which python` still returns miniforge3's Python 3.12 rather than the env's Python.
 
-## Snakemake directory locks persist across failed runs
-If snakemake is killed or a concurrent instance tries to run, the `.snakemake` lock persists. Always `pixi run unlock` before re-launching. Check `pgrep -af snakemake` to ensure no stale processes hold the lock.
-**Why:** Several launch attempts failed silently due to stale locks from previous attempts.
+**Why:** The conda shell hook isn't initialized in a non-interactive bash subprocess when miniforge3 is already at the front of PATH.
 
-## zarr v3 API breaks: no context manager, `.array()` → `.create_array()`, no `codecs` kwarg
-In zarr v3, `zarr.open()` returns a `Group` that does NOT support `with` (context manager). Use plain assignment instead. `group.array(name=..., data=...)` is removed — use `group.create_array(name=..., data=...)`. For sharded writes, use `create_array(chunks=..., shards=..., compressors=...)` — the old `codecs=[ShardingCodec(...).to_dict()]` parameter is gone.
-**Why:** The conda env had zarr 3.1.5 installed. All three of these broke the aggregate and rechunk scripts simultaneously.
+**Fix:** Use `shell:` directive and invoke the conda env's Python directly by absolute path:
+```smk
+shell:
+    """
+    CONDA_PYTHON=/path/to/conda/envs/HASH/bin/python
+    $CONDA_PYTHON scripts/myscript.py --arg {wildcards.x} >> {log} 2>&1
+    """
+```
+This requires the script to have an argparse CLI (not just the magic `snakemake` object).
+
+**Conda env hashes for this project:**
+- Download env (boto3): `507f1bacc8e964624ea0c0fc2f042010_`
+- Extract env (SPARCSpy): `79ff5f567d72279473b1703565acfd26_`
+- Env prefix: `/ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs/`
+
+---
 
 ## pixi task `env.PATH` prepend shadows conda env Python
+
 If `pixi.toml` sets `env = { PATH = "/path/to/miniforge3/bin:$PATH" }`, the base miniforge Python takes precedence over any conda env activated by snakemake via `source activate`. Fix: put miniforge3/bin at the END of PATH (`$PATH:/path/to/miniforge3/bin`). Conda is still findable but won't shadow the activated env's Python.
 **Why:** Spent significant time debugging why `import dask` failed — snakemake was running base Python 3.12 (no dask) instead of the conda env's Python 3.14 (has dask). Debug output showing `sys.executable` was the key diagnostic.
 
+---
+
+## System snakemake (v7) has broken pulp dependency
+
+The system-installed snakemake 7.32.4 at `~/.local/bin/snakemake` fails with `AttributeError: module 'pulp' has no attribute 'list_solvers'` due to PuLP 2.9 removing that function. Fix: use pixi to install snakemake 8 (as source_03 does). Don't try to downgrade PuLP — the system has multiple Python versions (3.9 for snakemake, 3.12 for pip) making it messy.
+**Why:** Lost 20 min debugging this. Use pixi for snakemake everywhere.
+
+---
+
+## pixi run needs cwd to contain pixi.toml
+
+`pixi run` looks for `pixi.toml` in the current working directory. Use `--manifest-path` if running from elsewhere, or ensure the shell cd's first. In Claude Code, bash tool resets cwd between calls unless cd is chained in the same command.
+**Why:** Multiple failed pipeline launch attempts due to wrong cwd.
+
+---
+
+## Snakemake directory locks persist across failed runs
+
+If snakemake is killed or a concurrent instance tries to run, the `.snakemake` lock persists. Always `pixi run unlock` before re-launching. Check `pgrep -af snakemake` to ensure no stale processes hold the lock.
+**Why:** Several launch attempts failed silently due to stale locks from previous attempts.
+
+---
+
+## Lock files can be numbered — clear ALL of them
+
+Snakemake creates `0.input.lock`, `0.output.lock`, `1.output.lock`, etc. Clearing only `0.*` misses numbered locks. Use:
+```bash
+find .snakemake/locks/ -name "*.lock" -delete
+```
+Not `rm -f .snakemake/locks/0.*.lock`.
+
+---
+
+## Snakemake gets stuck in shutdown on NFS after job failures
+
+After all retries for a failed job are exhausted, snakemake prints "Shutting down, this might take some time" / "Exiting because a job execution failed" but the process never exits. It hangs indefinitely in Python multiprocessing cleanup blocked on NFS.
+
+**Fix:** `kill -9 <PID>`, then clear stale locks before restarting:
+```bash
+rm -f .snakemake/locks/*.lock
+```
+`pixi run unlock` also works but rebuilds the full DAG (~30 min) — manual delete is faster.
+
+---
+
+## kill -9 on snakemake doesn't kill child processes
+
+`kill -9` on the snakemake parent leaves all child bash/python processes as orphans. They continue running and consuming resources.
+
+**Fix:** After killing snakemake, also kill orphaned children:
+```bash
+ps aux | grep "scripts/extract.py" | grep -v grep | awk '{print $2}' | xargs kill -9
+```
+
+---
+
+## NFS write cache causes severe log lag
+
+On this cluster, NFS write caching can cause log files and directory listings to appear frozen for 30–60+ minutes even when the pipeline is actively writing. `stat` on the log file will show a stale mtime. The process count (`ps aux | grep snakemake`) is the reliable liveness indicator.
+
+**How to check real progress:** Count output files directly on disk rather than relying on log messages.
+
+---
+
+## Snakemake DAG build is slow on NFS with large job counts
+
+For ~6000+ jobs, DAG construction takes 30–35 minutes on NFS. Plan for this when restarting the pipeline — the pipeline isn't hung, it's just building.
+
+---
+
+## GPU is NOT the bottleneck — NFS IO is
+
+For this SPARCSpy cellpose pipeline, each batch has two phases:
+- Cellpose segmentation (GPU): ~2 min per batch (fast)
+- HDF5 cell extraction (CPU+NFS IO): ~16 min per batch (slow)
+
+The GPU (A100 80GB) is idle ~85% of the time. The bottleneck is writing memory-mapped temp arrays and HDF5 files over NFS.
+
+**What actually speeds things up:**
+1. Local NVMe for `tmpdir` and extraction results — biggest win
+2. More parallel jobs (raise `vram_mb`, `mem_mb`, `cores` in profile)
+3. More CPU cores on the node
+4. Bigger GPU does NOT help
+
+**Working profile for 12 parallel jobs (confirmed stable):**
+```yaml
+cores: 12       # THE reliable concurrency cap — mem_mb doesn't work!
+resources:
+  vram_mb: 70000
+  mem_mb: 240000
+```
+Note: `cores` is the only reliable way to limit concurrency. See "Snakemake resources doesn't reliably cap concurrency" lesson.
+
+---
+
+## Snakemake `resources` in profile doesn't reliably cap concurrency — use `cores`
+
+Setting `resources: mem_mb: 240000` in the profile YAML with each job needing `mem_mb=20000` should cap at 12 jobs. In practice, snakemake 8 scheduled 33+ concurrent jobs, ignoring the constraint entirely.
+
+**Fix:** Use `cores: 12` as a hard cap. Since extract jobs don't declare `threads`, each counts as 1 core. This reliably limits concurrency.
+
+---
+
+## zarr v3 API breaks: no context manager, `.array()` → `.create_array()`, no `codecs` kwarg
+
+In zarr v3, `zarr.open()` returns a `Group` that does NOT support `with` (context manager). Use plain assignment instead. `group.array(name=..., data=...)` is removed — use `group.create_array(name=..., data=...)`. For sharded writes, use `create_array(chunks=..., shards=..., compressors=...)` — the old `codecs=[ShardingCodec(...).to_dict()]` parameter is gone.
+**Why:** The conda env had zarr 3.1.5 installed. All three of these broke the aggregate and rechunk scripts simultaneously.
+
+---
+
 ## Concurrent zarr.open() in mode "a" races on store initialization
+
 When using ProcessPoolExecutor, multiple workers calling `zarr.open(path, mode="a")` on a new store race to create zarr metadata. Fix: initialize the store once with `zarr.open(path, mode="w")` in the parent process before spawning workers. Workers then open with `mode="a"`.
 **Why:** Got `ContainsGroupError` when 15 workers simultaneously tried to open a fresh store.
 
+---
+
+## How to check per-source pipeline progress
+
+Run `scripts/check_progress.sh` (see that file). It reports for each source:
+- extractions done on disk vs total batches (from metadata parquet)
+- images downloaded
+- broad batches aggregated
+- whether final aggregate exists
+
+The key insight: **don't trust log file counts** (NFS lag). Count output files on disk instead.
+
+---
+
+## TiffFileError from S3 empty response is transient
+
+`TiffFileError: not a TIFF file: header=b''` means S3 returned an empty body. This is a transient network issue. With `retries: 5` in the rule, the job gets 5 attempts. If all fail in one run, they get 5 fresh retries on the next restart.
+
+---
+
 ## Download .npy files disappearing doesn't mean download failed
+
 The extract rule consumes the .npy but it's not marked `temp()` — however, if the pipeline is killed mid-run and restarted, snakemake may re-download. Missing .npy files with existing download logs means the pipeline was interrupted, not that downloads failed.
 **Why:** Initially misdiagnosed as download script ending prematurely.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,30 +1,60 @@
-# Source 04 Pipeline TODO
+# JUMP CPG0016 Segmentation — Task Tracker
 
-## Pipeline Run (2026-04-07)
-- [x] Diagnosed why source_4 only had 244/708 batches: May 2025 re-run was killed mid-execution; original Feb 2024 run had completed all 708
-- [x] Deleted `results_old/` (completed but outdated first run with wrong diameters)
-- [x] Switched repo to `main` branch (reset to `origin/main`, PR #9 merged) while preserving source_4-specific config changes
-- [x] Fixed snakemake — installed snakemake 8 via pixi (system snakemake 7 had broken pulp dependency)
-- [x] Created `pixi.toml` for source_04 (mirroring source_03 setup)
-- [x] Updated `profile/config.yaml` for current SLURM allocation: 15 cores, 80GB VRAM, 300GB RAM
-- [x] Pipeline running: 1652 total steps (464 downloads + 476 extracts + 708 aggregate_broad_batch + create_broad_structure + rechunk_broad + aggregate)
-- [x] Monitor pipeline to completion — all 1652 download/extract jobs done, 708 aggregate_broad_batch completed
-- [x] Resume pipeline on new SLURM node
-- [x] Fixed zarr v3 incompatibility in `aggregate_broad_batch.py`: removed context manager on `zarr.open()`, changed `.array()` → `.create_array()`
-- [x] Fixed PATH ordering in `pixi.toml`: miniforge3/bin moved to end of PATH so conda env Python (3.14) takes precedence over base (3.12)
-- [x] Fixed zarr v3 incompatibility in `rechunk_broad.py`: replaced dask `to_zarr()` with native zarr v3 `create_array()` using `shards`/`chunks`/`compressors`; removed `zarr_version=3` param; initialized store with `mode="w"` before spawning workers
-- [x] Pipeline completed successfully (2026-04-08 19:22) — all 277 plates rechunked, aggregate checkpoint written
+## Pipeline Fixes (snakemake repo: theislab/jump-cpg0016-segmentation)
+
+- [x] Fix `download_stacks` rule: replaced `conda:` + `script:` with `shell:` using direct conda env Python path (`507f1bacc8e964624ea0c0fc2f042010_`)
+  - Files: `snakemake/rules/download.smk`, `snakemake/scripts/download_stack.py`
+- [x] Fix `extract` rule: same pattern — replaced `conda:` + `script:` with `shell:` using direct conda env Python path (`79ff5f567d72279473b1703565acfd26_`)
+  - Files: `snakemake/rules/extract.smk`, `snakemake/scripts/extract.py`
+- [x] Add argparse CLI to `download_stack.py` so it can be called from `shell:` (previously only had magic `snakemake` object support)
+- [x] Add argparse CLI to `extract.py` (same reason)
+- [x] Add rechunk_broad rule for sharded Zarr v3 compression (separate prior commit)
+- [x] All above pushed to PR #9 (`feat/rechunk-snakemake-rule`): https://github.com/theislab/jump-cpg0016-segmentation/pull/9
+- [x] PR #9 merged to main
+- [x] Fixed zarr v3 incompatibility in `aggregate_broad_batch.py`: removed context manager on `zarr.open()`, changed `.array()` → `.create_array()` (PR #11)
+- [x] Fixed zarr v3 incompatibility in `rechunk_broad.py`: replaced dask `to_zarr()` with native zarr v3 `create_array()` using `shards`/`chunks`/`compressors`; initialized store before workers (PR #11)
+- [x] Added pixi.toml for snakemake 8 (PR #11)
+
+## Per-Source Pipeline Status
+
+- [x] sources 02, 08, 10: Fully complete (final aggregate exists).
+- [x] **source04**: Completed 2026-04-08. All 708 batches extracted, 277 plates rechunked, aggregate checkpoint written.
+- [ ] **source03**: 98.6% done (4128/4186 batches extracted). Not currently running — needs restart for last 58 batches, then aggregation.
+- [ ] **source06**: 100% extraction done (3207/3206), 2 broad batches aggregated — needs aggregation pipeline run.
+- [ ] **source13**: 100% extraction done (286/286 batches) — needs aggregation pipeline run.
+- [ ] **source05**: 80.5% done (2896/3595 batches). Not running.
+- [ ] **source09**: 64.7% done (1717/2652 batches). Not running.
+- [ ] **source11**: 73.7% done (1779/2415 batches). Not running.
+- [ ] **source07**: 53.9% done (953/1769 batches). Not running.
+- [ ] Kick off remaining sources on separate nodes
+
+## Source 04 Completed Items
+
+- [x] Diagnosed why source_4 only had 244/708 batches: May 2025 re-run was killed mid-execution
+- [x] Installed snakemake 8 via pixi, created pixi.toml, updated profile (15 cores, 80GB VRAM, 300GB RAM)
+- [x] Pipeline completed successfully (2026-04-08 19:22) — all 277 plates rechunked
 - [ ] Verify rechunked compressed output integrity (spot-check a few plates)
-- [ ] Clean up leftover temp mmap dirs in `results/tmp/`
-- [ ] Clean up duplicate log files in `../log/` from failed launch attempts (output_202604071139 through 202604071154)
-- [ ] Replicate zarr v3 fixes to other source pipelines (source_02, source_03, source_08, source_13) if they use the same scripts
+- [ ] Clean up leftover temp mmap dirs in source04 `results/tmp/` (40 dirs from May 2025)
+- [ ] Clean up duplicate log files from failed launch attempts
+
+## Performance
+
+- [x] Profiled bottleneck: HDF5 extraction over NFS (~16 min/batch) dominates; GPU cellpose takes only ~2 min
+- [x] Raised profile limits: vram_mb 15k→70k, mem_mb 100k→240k
+- [x] Discovered `mem_mb` resource limit doesn't cap snakemake concurrency — `cores` is the reliable lever
+- [x] Set `cores: 12` as hard cap (12 parallel extract jobs confirmed working)
+
+## Downstream
+
+- [ ] Replicate zarr v3 fixes to other source pipelines if they use older scripts
+- [ ] Verify rechunk_broad Zarr v3 output is correct before running on all sources
+- [ ] Final aggregate step for all sources still pending
 
 ## Config Notes (source_4-specific, NOT committed to main)
-- `samples.json`: `{"samples": [{"Metadata_Source": "source_4"}]}` (selects all 176,845 samples = 708 batches)
+- `samples.json`: `{"samples": [{"Metadata_Source": "source_4"}]}` (708 batches)
 - `sparcspy.yml`: nucleus diameter=25, cytosol diameter=69 (differs from repo default of 21/53)
 - `profile/config.yaml`: 15 cores, vram_mb=80000, mem_mb=300000
 
 ## Known Issues
-- 12 batches were previously incomplete (64, 124, 125, 245, 364, 365, 454, 484, 485, 544, 574, 604) — being re-run with `--rerun-incomplete`
 - Extract rule outputs are marked `temp()` — extraction/segmentation H5 files get deleted after downstream rules consume them
 - Snakemake warns about `directory` flag used in inputs for `aggregate_broad_batch` and `rechunk_broad` rules (non-fatal)


### PR DESCRIPTION
## Summary
- `tasks/todo.md`: per-source segmentation pipeline progress tracker, open kickoff items, PR #9 reference
- `tasks/lessons.md`: documented non-obvious patterns found during debugging — conda activation failure in pixi, NFS log lag, snakemake stuck shutdown on NFS, transient S3 TiffFileError

## Open items
- Sources 04, 05, 06, 07 need to be kicked off
- PR #9 (`feat/rechunk-snakemake-rule`) needs merge after source03 completes successfully