### PR TITLE
Add pixi snakemake env and source04 run config

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,63 @@
+# Source 04 Pipeline Handover
+
+## Status as of 2026-04-08 ~02:00
+- **883/1652 jobs done (53%)**, 0 errors
+- 689/708 images downloaded, 689 extraction dirs, 689 segmentation dirs
+- ~19 remaining downloads, ~19 remaining extracts, 708 aggregate_broad_batch, 1 create_broad_structure, 1 rechunk_broad, 1 aggregate
+- Pipeline will be killed when SLURM node dies (~2 min left)
+
+## Folder Paths
+- **Pipeline root:** `/ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source04/`
+- **Snakemake dir (run from here):** `/ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source04/snakemake/`
+- **Pixi env:** `/ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source04/snakemake/.pixi/`
+- **Pipeline logs:** `/ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source04/log/`
+- **Active log (this run):** `output_202604071156_stderr.log`
+- **Extract logs:** `snakemake/log/extract/source_4/`
+- **Config:** `snakemake/config/` (samples.json = source_4 only, sparcspy.yml = diam 25/69)
+- **Profile:** `snakemake/profile/config.yaml` (15 cores, 80GB VRAM, 300GB RAM)
+- **Results:** `snakemake/results/{images,extraction,segmentation,sparcspy,tmp}/`
+- **Conda envs (shared, do not delete):** `/ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs/`
+- **Git repo:** `theislab/jump-cpg0016-segmentation`, branch `add-pixi-and-source04-config`, PR #11
+
+## Resume Steps
+1. Request new SLURM node (needs GPU, >=300GB RAM, >=15 cores):
+   ```bash
+   srun --partition=gpu_p --qos=gpu_normal --gres=gpu:1 --mem=300G --cpus-per-task=15 --time=1-00:00:00 --pty bash
+   ```
+2. cd to snakemake dir:
+   ```bash
+   cd /ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source04/snakemake
+   ```
+3. Unlock (the kill will leave a stale lock):
+   ```bash
+   pixi run unlock
+   ```
+4. Adjust profile if new node has different resources:
+   ```bash
+   cat profile/config.yaml  # check cores/mem/vram values match your allocation
+   ```
+5. Run:
+   ```bash
+   timestamp=$(date +"%Y%m%d%H%M")
+   pixi run run > "../log/output_${timestamp}_stdout.log" 2> "../log/output_${timestamp}_stderr.log" &
+   ```
+6. Verify it started:
+   ```bash
+   sleep 30 && tail -20 ../log/output_${timestamp}_stderr.log
+   ```
+
+## Source 04 Config (DO NOT LOSE)
+These are source-specific overrides, not committed to main:
+- **samples.json:** `{"samples": [{"Metadata_Source": "source_4"}]}`
+- **sparcspy.yml:** nucleus diameter=25, cytosol diameter=69
+- **profile/config.yaml:** 15 cores, vram_mb=80000, mem_mb=300000
+
+## What Snakemake Will Do on Resume
+- `--rerun-incomplete` will re-run any batches that were mid-extract when killed
+- It will skip already-completed downloads/extractions (output files exist)
+- Remaining work: ~19 downloads, ~19 extracts, then all 708 aggregate_broad_batch jobs, create_broad_structure, rechunk_broad
+
+## Other Sources Still Pending
+- source05: 81% done, source06: ~100% extraction, source07: 54%
+- source09: 65%, source11: 74%, source13: ~100% extraction
+- Each needs its own node; same resume pattern applies

--- a/snakemake/pixi.toml
+++ b/snakemake/pixi.toml
@@ -6,9 +6,9 @@ platforms = ["linux-64"]
 version = "0.1.0"
 
 [tasks]
-run = { cmd = "snakemake --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs", env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" } }
-dryrun = { cmd = "snakemake --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs -n", env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" } }
-unlock = { cmd = "snakemake --unlock --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs", env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" } }
+run = { cmd = "snakemake --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs", env = { PATH = "$PATH:/home/icb/tim.treis/miniforge3/bin" } }
+dryrun = { cmd = "snakemake --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs -n", env = { PATH = "$PATH:/home/icb/tim.treis/miniforge3/bin" } }
+unlock = { cmd = "snakemake --unlock --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs", env = { PATH = "$PATH:/home/icb/tim.treis/miniforge3/bin" } }
 
 [dependencies]
 snakemake = ">=8,<9"

--- a/snakemake/pixi.toml
+++ b/snakemake/pixi.toml
@@ -1,0 +1,15 @@
+[workspace]
+authors = ["Tim Treis <tim.treis@helmholtz-munich.de>"]
+channels = ["conda-forge", "bioconda"]
+name = "final_source04"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+run = { cmd = "snakemake --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs", env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" } }
+dryrun = { cmd = "snakemake --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs -n", env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" } }
+unlock = { cmd = "snakemake --unlock --profile profile --use-conda --conda-prefix /ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs", env = { PATH = "/home/icb/tim.treis/miniforge3/bin:$PATH" } }
+
+[dependencies]
+snakemake = ">=8,<9"
+snakemake-minimal = "*"

--- a/snakemake/profile/config.yaml
+++ b/snakemake/profile/config.yaml
@@ -1,7 +1,7 @@
-cores: 20
+cores: 15
 use-conda: True
 keep-incomplete: True
 rerun-incomplete: True
 resources:
-  vram_mb: 15000
-  mem_mb: 100000
+  vram_mb: 80000
+  mem_mb: 300000

--- a/snakemake/scripts/aggregate_broad_batch.py
+++ b/snakemake/scripts/aggregate_broad_batch.py
@@ -66,13 +66,13 @@ def _aggregate(
                 0
             ].tolist()
 
-            with zarr.open(str(output_path.resolve()), mode="a") as out_zarr:
-                image_group = out_zarr.create_group(image_id, overwrite=debug)
-                image_group.array(name="label_image", data=segmentation_file["segmentation"][image_idx])
-                image_group.array(name="single_cell_index", data=extraction_file["single_cell_index"][cell_indices])
-                image_group.array(name="single_cell_data", data=extraction_file["single_cell_data"][cell_indices])
+            out_zarr = zarr.open(str(output_path.resolve()), mode="a")
+            image_group = out_zarr.create_group(image_id, overwrite=debug)
+            image_group.create_array(name="label_image", data=segmentation_file["segmentation"][image_idx])
+            image_group.create_array(name="single_cell_index", data=extraction_file["single_cell_index"][cell_indices])
+            image_group.create_array(name="single_cell_data", data=extraction_file["single_cell_data"][cell_indices])
 
-                module_logger.info(f"{image_id} wrote to {output_path.name}")
+            module_logger.info(f"{image_id} wrote to {output_path.name}")
 
 
 def main(snakemake):

--- a/snakemake/scripts/rechunk_broad.py
+++ b/snakemake/scripts/rechunk_broad.py
@@ -3,12 +3,10 @@ import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
-import dask
-import dask.array as da
+import numpy as np
 import zarr
 from numcodecs import blosc
-from zarr.codecs import BloscCodec, BytesCodec, ShardingCodec
-from zarr.storage import LocalStore
+from zarr.codecs import BloscCodec
 
 module_logger = logging.getLogger(__name__)
 
@@ -16,7 +14,6 @@ SUBGROUPS = ["label_image", "single_cell_data", "single_cell_index"]
 CELL_CHUNK_SIZE = 1
 CELLS_PER_SHARD = 4096
 COMPRESSOR = BloscCodec(cname="zstd", clevel=3, shuffle="shuffle")
-CODECS_PIPELINE = (BytesCodec(), COMPRESSOR)
 BLOSC_THREADS = 1  # per-worker; each subprocess sets this independently
 
 
@@ -31,42 +28,42 @@ def _target_chunks_and_shard_shape(shape):
 def process_group(store_path, new_store_path, group_name):
     """Rechunk a single image group into per-cell sharded Zarr v3. Called in a subprocess."""
     blosc.set_nthreads(BLOSC_THREADS)
-    dask.config.set(scheduler="threads", num_workers=1)
 
     src = zarr.open(store_path, mode="r")
     if group_name not in src:
         return
 
     src_group = src[group_name]
-    target_store = LocalStore(str(new_store_path))
+    dst = zarr.open(new_store_path, mode="a")
 
     for sub in SUBGROUPS:
         if sub not in src_group:
             continue
         src_ds = src_group[sub]
-        darray = da.from_zarr(src_ds)
-        target_chunks, shard_chunk = _target_chunks_and_shard_shape(darray.shape)
-        if shard_chunk is None:
+        data = np.asarray(src_ds)
+        shard_shape, chunk_shape = _target_chunks_and_shard_shape(data.shape)
+        if chunk_shape is None:
             module_logger.warning(f"Skipping {group_name}/{sub}: scalar array.")
             continue
-        sharding_codec = ShardingCodec(chunk_shape=shard_chunk, codecs=CODECS_PIPELINE)
-        darray_rechunked = darray.rechunk(target_chunks)
-        darray_rechunked.to_zarr(
-            target_store,
-            component=f"{group_name}/{sub}",
+        dst.create_array(
+            name=f"{group_name}/{sub}",
+            data=data,
+            chunks=chunk_shape,
+            shards=shard_shape,
+            compressors=COMPRESSOR,
             overwrite=True,
-            compute=True,
-            zarr_version=3,
-            codecs=[sharding_codec.to_dict()],
         )
 
 
 def rechunk_plate(store_path: Path, n_workers: int):
     new_store_path = Path(str(store_path).replace("/broad/", "/broad_compressed/"))
-    os.makedirs(new_store_path, exist_ok=True)
+    os.makedirs(new_store_path.parent, exist_ok=True)
 
     src = zarr.open(str(store_path), mode="r")
     groups = list(src.group_keys())
+
+    # Initialize the zarr store once before spawning workers
+    zarr.open(str(new_store_path), mode="w")
 
     with ProcessPoolExecutor(max_workers=n_workers) as executor:
         futures = [
@@ -74,7 +71,7 @@ def rechunk_plate(store_path: Path, n_workers: int):
             for group_name in groups
         ]
         for future in as_completed(futures):
-            future.result()
+            future.result()  # raises if the subprocess failed
 
 
 def main(snakemake):

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -12,6 +12,18 @@ The system-installed snakemake 7.32.4 at `~/.local/bin/snakemake` fails with `At
 If snakemake is killed or a concurrent instance tries to run, the `.snakemake` lock persists. Always `pixi run unlock` before re-launching. Check `pgrep -af snakemake` to ensure no stale processes hold the lock.
 **Why:** Several launch attempts failed silently due to stale locks from previous attempts.
 
+## zarr v3 API breaks: no context manager, `.array()` → `.create_array()`, no `codecs` kwarg
+In zarr v3, `zarr.open()` returns a `Group` that does NOT support `with` (context manager). Use plain assignment instead. `group.array(name=..., data=...)` is removed — use `group.create_array(name=..., data=...)`. For sharded writes, use `create_array(chunks=..., shards=..., compressors=...)` — the old `codecs=[ShardingCodec(...).to_dict()]` parameter is gone.
+**Why:** The conda env had zarr 3.1.5 installed. All three of these broke the aggregate and rechunk scripts simultaneously.
+
+## pixi task `env.PATH` prepend shadows conda env Python
+If `pixi.toml` sets `env = { PATH = "/path/to/miniforge3/bin:$PATH" }`, the base miniforge Python takes precedence over any conda env activated by snakemake via `source activate`. Fix: put miniforge3/bin at the END of PATH (`$PATH:/path/to/miniforge3/bin`). Conda is still findable but won't shadow the activated env's Python.
+**Why:** Spent significant time debugging why `import dask` failed — snakemake was running base Python 3.12 (no dask) instead of the conda env's Python 3.14 (has dask). Debug output showing `sys.executable` was the key diagnostic.
+
+## Concurrent zarr.open() in mode "a" races on store initialization
+When using ProcessPoolExecutor, multiple workers calling `zarr.open(path, mode="a")` on a new store race to create zarr metadata. Fix: initialize the store once with `zarr.open(path, mode="w")` in the parent process before spawning workers. Workers then open with `mode="a"`.
+**Why:** Got `ContainsGroupError` when 15 workers simultaneously tried to open a fresh store.
+
 ## Download .npy files disappearing doesn't mean download failed
 The extract rule consumes the .npy but it's not marked `temp()` — however, if the pipeline is killed mid-run and restarted, snakemake may re-download. Missing .npy files with existing download logs means the pipeline was interrupted, not that downloads failed.
 **Why:** Initially misdiagnosed as download script ending prematurely.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,17 @@
+# Lessons Learned
+
+## System snakemake (v7) has broken pulp dependency
+The system-installed snakemake 7.32.4 at `~/.local/bin/snakemake` fails with `AttributeError: module 'pulp' has no attribute 'list_solvers'` due to PuLP 2.9 removing that function. Fix: use pixi to install snakemake 8 (as source_03 does). Don't try to downgrade PuLP — the system has multiple Python versions (3.9 for snakemake, 3.12 for pip) making it messy.
+**Why:** Lost 20 min debugging this. Use pixi for snakemake everywhere.
+
+## pixi run needs cwd to contain pixi.toml
+`pixi run` looks for `pixi.toml` in the current working directory. Use `--manifest-path` if running from elsewhere, or ensure the shell cd's first. In Claude Code, bash tool resets cwd between calls unless cd is chained in the same command.
+**Why:** Multiple failed pipeline launch attempts due to wrong cwd.
+
+## Snakemake directory locks persist across failed runs
+If snakemake is killed or a concurrent instance tries to run, the `.snakemake` lock persists. Always `pixi run unlock` before re-launching. Check `pgrep -af snakemake` to ensure no stale processes hold the lock.
+**Why:** Several launch attempts failed silently due to stale locks from previous attempts.
+
+## Download .npy files disappearing doesn't mean download failed
+The extract rule consumes the .npy but it's not marked `temp()` — however, if the pipeline is killed mid-run and restarted, snakemake may re-download. Missing .npy files with existing download logs means the pipeline was interrupted, not that downloads failed.
+**Why:** Initially misdiagnosed as download script ending prematurely.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,25 @@
+# Source 04 Pipeline TODO
+
+## Pipeline Run (2026-04-07)
+- [x] Diagnosed why source_4 only had 244/708 batches: May 2025 re-run was killed mid-execution; original Feb 2024 run had completed all 708
+- [x] Deleted `results_old/` (completed but outdated first run with wrong diameters)
+- [x] Switched repo to `main` branch (reset to `origin/main`, PR #9 merged) while preserving source_4-specific config changes
+- [x] Fixed snakemake — installed snakemake 8 via pixi (system snakemake 7 had broken pulp dependency)
+- [x] Created `pixi.toml` for source_04 (mirroring source_03 setup)
+- [x] Updated `profile/config.yaml` for current SLURM allocation: 15 cores, 80GB VRAM, 300GB RAM
+- [x] Pipeline running: 1652 total steps (464 downloads + 476 extracts + 708 aggregate_broad_batch + create_broad_structure + rechunk_broad + aggregate)
+- [ ] Monitor pipeline to completion — as of handoff, **290/1652 jobs done (18%)**, 0 errors, GPU 100%
+- [ ] After pipeline completes: verify all 708 extraction/segmentation dirs exist
+- [ ] After pipeline completes: verify aggregated Zarr output and rechunked compressed output
+- [ ] Clean up leftover temp mmap dirs in `results/tmp/`
+- [ ] Clean up duplicate log files in `../log/` from failed launch attempts (output_202604071139 through 202604071154)
+
+## Config Notes (source_4-specific, NOT committed to main)
+- `samples.json`: `{"samples": [{"Metadata_Source": "source_4"}]}` (selects all 176,845 samples = 708 batches)
+- `sparcspy.yml`: nucleus diameter=25, cytosol diameter=69 (differs from repo default of 21/53)
+- `profile/config.yaml`: 15 cores, vram_mb=80000, mem_mb=300000
+
+## Known Issues
+- 12 batches were previously incomplete (64, 124, 125, 245, 364, 365, 454, 484, 485, 544, 574, 604) — being re-run with `--rerun-incomplete`
+- Extract rule outputs are marked `temp()` — extraction/segmentation H5 files get deleted after downstream rules consume them
+- Snakemake warns about `directory` flag used in inputs for `aggregate_broad_batch` and `rechunk_broad` rules (non-fatal)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,12 +8,16 @@
 - [x] Created `pixi.toml` for source_04 (mirroring source_03 setup)
 - [x] Updated `profile/config.yaml` for current SLURM allocation: 15 cores, 80GB VRAM, 300GB RAM
 - [x] Pipeline running: 1652 total steps (464 downloads + 476 extracts + 708 aggregate_broad_batch + create_broad_structure + rechunk_broad + aggregate)
-- [ ] Monitor pipeline to completion — **883/1652 jobs done (53%)** as of node death (2026-04-08 ~02:00), 0 errors
-- [ ] Resume pipeline on new SLURM node — see `HANDOVER.md` for exact steps (`pixi run unlock` then `pixi run run`)
-- [ ] After pipeline completes: verify all 708 extraction/segmentation dirs exist
-- [ ] After pipeline completes: verify aggregated Zarr output and rechunked compressed output
+- [x] Monitor pipeline to completion — all 1652 download/extract jobs done, 708 aggregate_broad_batch completed
+- [x] Resume pipeline on new SLURM node
+- [x] Fixed zarr v3 incompatibility in `aggregate_broad_batch.py`: removed context manager on `zarr.open()`, changed `.array()` → `.create_array()`
+- [x] Fixed PATH ordering in `pixi.toml`: miniforge3/bin moved to end of PATH so conda env Python (3.14) takes precedence over base (3.12)
+- [x] Fixed zarr v3 incompatibility in `rechunk_broad.py`: replaced dask `to_zarr()` with native zarr v3 `create_array()` using `shards`/`chunks`/`compressors`; removed `zarr_version=3` param; initialized store with `mode="w"` before spawning workers
+- [x] Pipeline completed successfully (2026-04-08 19:22) — all 277 plates rechunked, aggregate checkpoint written
+- [ ] Verify rechunked compressed output integrity (spot-check a few plates)
 - [ ] Clean up leftover temp mmap dirs in `results/tmp/`
 - [ ] Clean up duplicate log files in `../log/` from failed launch attempts (output_202604071139 through 202604071154)
+- [ ] Replicate zarr v3 fixes to other source pipelines (source_02, source_03, source_08, source_13) if they use the same scripts
 
 ## Config Notes (source_4-specific, NOT committed to main)
 - `samples.json`: `{"samples": [{"Metadata_Source": "source_4"}]}` (selects all 176,845 samples = 708 batches)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,7 +8,8 @@
 - [x] Created `pixi.toml` for source_04 (mirroring source_03 setup)
 - [x] Updated `profile/config.yaml` for current SLURM allocation: 15 cores, 80GB VRAM, 300GB RAM
 - [x] Pipeline running: 1652 total steps (464 downloads + 476 extracts + 708 aggregate_broad_batch + create_broad_structure + rechunk_broad + aggregate)
-- [ ] Monitor pipeline to completion — as of handoff, **290/1652 jobs done (18%)**, 0 errors, GPU 100%
+- [ ] Monitor pipeline to completion — **883/1652 jobs done (53%)** as of node death (2026-04-08 ~02:00), 0 errors
+- [ ] Resume pipeline on new SLURM node — see `HANDOVER.md` for exact steps (`pixi run unlock` then `pixi run run`)
 - [ ] After pipeline completes: verify all 708 extraction/segmentation dirs exist
 - [ ] After pipeline completes: verify aggregated Zarr output and rechunked compressed output
 - [ ] Clean up leftover temp mmap dirs in `results/tmp/`


### PR DESCRIPTION
## Summary
- Add `pixi.toml` with snakemake 8 for source04 (mirroring source03 setup) — system snakemake 7 has broken PuLP dependency
- Update `profile/config.yaml` for current SLURM allocation (15 cores, 80GB VRAM, 300GB RAM)
- Add `tasks/todo.md` and `tasks/lessons.md` documenting pipeline status and operational learnings

## Context
Source04 pipeline is currently running on gpusrv71: 290/1652 jobs done (18%), 0 errors. The metadata has 708 batches (176,845 samples) but only 244 had been processed from a previous interrupted run. This session diagnosed the issue, set up pixi, and restarted the full pipeline.

## Test plan
- [x] `pixi run dryrun` succeeds
- [x] `pixi run run` launches pipeline correctly with 15 concurrent jobs
- [ ] Full pipeline completion (estimated ~43h)