### PR TITLE
Standardize aggregate env to zarr v3

### DIFF
--- a/snakemake/envs/aggregate_broad.yml
+++ b/snakemake/envs/aggregate_broad.yml
@@ -1,7 +1,7 @@
-name: aggregate_sources
+name: aggregate_broad
 channels:
   - conda-forge
 dependencies:
   - h5py
   - numpy
-  - ome-zarr
+  - zarr>=3

--- a/tasks/RUNBOOK.md
+++ b/tasks/RUNBOOK.md
@@ -1,0 +1,267 @@
+# JUMP CPG0016 Segmentation — Pipeline Runbook
+
+Self-contained instructions for running the segmentation pipeline on GPU cluster nodes.
+Last updated: 2026-04-10.
+
+---
+
+## Quick Reference
+
+| Source | Batches | Extracted | Status | What To Do |
+|--------|---------|-----------|--------|------------|
+| 02 | TBD (full source, no filters) | previously complete | needs full rerun | old run used subset filters; rerun from scratch for full source_2 |
+| 03 | 4186 | 4128 (98.6%) | not running | finish last 58 batches + aggregation |
+| 04 | 708 | previously complete | **needs full rerun** | diameters changed (was 25/69, now 23/57); old results invalid |
+| 05 | 3595 | 2896 (80.5%) | not running | continue extraction + aggregation |
+| 06 | 3207 | 3207 (100%) | **aggregation running** | started 2026-04-10 ~22:00; monitor |
+| 07 | 1769 | 953 (53.9%) | not running | continue extraction + aggregation |
+| 08 | TBD | previously complete | needs aggregation rerun | rerun aggregation with zarr v3 for consistency |
+| 09 | 2652 | 1717 (64.7%) | not running | continue extraction + aggregation |
+| 10 | TBD | previously complete | needs aggregation rerun | rerun aggregation with zarr v3 for consistency |
+| 11 | 2415 | 1779 (73.7%) | not running | continue extraction + aggregation |
+| 13 | 286 | 286 (100%) | not running | run pipeline (93 segmentations exist, rest will be filled) |
+
+### Priority Order
+
+1. **source06** — already running, just monitor
+2. **source13** — 286 batches, smallest source, quick win
+3. **source03** — only 58 batches left, then aggregation
+4. **source08/10** — aggregation-only reruns (extraction already done)
+5. **source02** — full rerun (old run used subset filters)
+6. **source05/09/11** — partially extracted, continue
+7. **source04/07** — largest remaining work
+
+---
+
+## How To Run a Source
+
+### 1. Get on a GPU node
+
+You need a node with:
+- 1x GPU (any NVIDIA, A100 preferred but not required — GPU is NOT the bottleneck)
+- 15+ CPU cores
+- 300+ GB RAM
+- NFS access to `/ictstr01/groups/ml01/`
+
+### 2. Navigate to the source directory
+
+```bash
+cd /ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source{NN}/snakemake
+```
+
+Replace `{NN}` with the source number (02, 03, 04, ..., 13).
+
+### 3. Verify the deployment is on current main
+
+```bash
+git log --oneline -1
+# Should show: d74cf93 Merge pull request #10 from theislab/add-tasks-and-lessons
+```
+
+If it doesn't, the source hasn't been migrated. See "Migration" section below.
+
+### 4. Check for stale locks
+
+```bash
+ls .snakemake/locks/
+```
+
+If there are `.lock` files:
+```bash
+# First check no snakemake is actually running
+pgrep -af "snakemake.*final_source{NN}"
+
+# If nothing running, clear locks
+find .snakemake/locks/ -name "*.lock" -delete
+```
+
+### 5. Dry run (optional but recommended for first time)
+
+```bash
+pixi run dryrun
+```
+
+This builds the DAG (~30 min for large sources on NFS) and shows what jobs will run. No actual work is done.
+
+### 6. Start the pipeline
+
+```bash
+pixi run run
+```
+
+This runs in the foreground. For background execution:
+```bash
+nohup pixi run run > ../log/run_$(date +%Y%m%d_%H%M%S).log 2>&1 &
+echo $! > ../log/snakemake.pid
+```
+
+### 7. Monitor progress
+
+**Do NOT trust log files** — NFS write cache causes 30-60+ minute lag.
+
+Count output files on disk instead:
+```bash
+# Extractions done
+ls results/extraction/source_{N}/ | wc -l
+
+# Segmentations done
+ls results/segmentation/source_{N}/ | wc -l
+
+# Aggregate batch checkpoints done
+ls results/checkpoints/aggregate_broad_batch/source_{N}/ 2>/dev/null | wc -l
+
+# Check if pipeline process is alive
+pgrep -af "snakemake.*final_source{NN}"
+```
+
+Or use the progress script from the repo root:
+```bash
+bash /ictstr01/groups/ml01/workspace/ttreis/projects/jump-cpg0016-segmentation/scripts/check_progress.sh
+```
+
+---
+
+## Special Cases
+
+### Sources needing FULL rerun (02, 04)
+
+For source04 (diameter change) and source02 (old subset filters), old results must be cleaned first:
+
+```bash
+cd /ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source{NN}/snakemake
+
+# Check what exists
+ls results/
+
+# Remove old extraction/segmentation/aggregation results
+# WARNING: This deletes data. Only do this for sources that need full rerun.
+rm -rf results/extraction/ results/segmentation/ results/aggregated/ results/checkpoints/
+rm -rf results/tmp/  # old temp mmap dirs
+
+# Then run normally
+pixi run run
+```
+
+### Sources needing aggregation-only rerun (08, 10)
+
+These have valid extraction+segmentation but need aggregation redone with zarr v3:
+
+```bash
+cd /ictstr01/groups/ml01/projects/2023_ttreis_segment_JUMP/snakemake/final_source{NN}/snakemake
+
+# Remove old aggregation outputs only
+rm -rf results/aggregated/ results/checkpoints/
+
+# Snakemake will see extraction+segmentation exist and only run aggregation rules
+pixi run run
+```
+
+### Source06 (currently running)
+
+Already running as of 2026-04-10 ~22:00. Pipeline steps:
+1. `create_broad_structure` — single job, iterates all 3207 batches to create dir layout
+2. `aggregate_broad_batch` × 3207 — per-batch zarr aggregation (15 parallel)
+3. `rechunk_broad` — compress all plates into sharded zarr v3
+4. `aggregate` — write final checkpoint to `results/aggregated/aggregate.txt`
+
+Check if still running:
+```bash
+pgrep -af "snakemake.*final_source06"
+```
+
+---
+
+## Standardized Config (all sources)
+
+Every source deployment has these local overrides (not committed to git):
+
+**`config/samples.json`**:
+```json
+{"samples": [{"Metadata_Source": "source_N"}]}
+```
+
+**`config/sparcspy.yml`** (diameters):
+- nucleus: 23
+- cytosol: 57
+
+**`profile/config.yaml`**:
+```yaml
+cores: 15
+use-conda: True
+keep-incomplete: True
+rerun-incomplete: True
+resources:
+  vram_mb: 80000
+  mem_mb: 300000
+```
+
+**`envs/aggregate_broad.yml`**: uses `zarr>=3` (NOT `ome-zarr`)
+
+---
+
+## Troubleshooting
+
+### Pipeline hangs after "Shutting down"
+Snakemake gets stuck in multiprocessing cleanup on NFS. Kill it:
+```bash
+kill -9 $(pgrep -f "snakemake.*final_source{NN}")
+# Also kill orphaned child processes
+ps aux | grep "scripts/extract.py" | grep -v grep | awk '{print $2}' | xargs kill -9 2>/dev/null
+# Clear locks before restarting
+find .snakemake/locks/ -name "*.lock" -delete
+```
+
+### Lock files blocking startup
+```bash
+find .snakemake/locks/ -name "*.lock" -delete
+```
+Don't use `pixi run unlock` — it rebuilds the full DAG (~30 min) just to unlock.
+
+### DAG build takes forever
+Normal. 30-35 min for ~6000+ jobs on NFS. The pipeline isn't hung, it's just building.
+
+### "TiffFileError: not a TIFF file: header=b''"
+Transient S3 empty response. The rule has `retries: 5`. If all fail, they get fresh retries on restart.
+
+### conda env creation fails
+The shared conda prefix is at:
+```
+/ictstr01/groups/ml01/projects/2023_hackathon23_subcellular_spatial_niklas.schmacke/jump/envs/
+```
+Key env hashes:
+- Download (boto3): `507f1bacc8e964624ea0c0fc2f042010_`
+- Extract (SPARCSpy): `79ff5f567d72279473b1703565acfd26_`
+- Aggregate broad (zarr v3): `d07e64204b55eb5dcc9dfdcb6fbe5b55_`
+- Rechunk (zarr v3 + dask): `67cb26037c82092ba47126f5b5e03793_`
+
+### GPU is idle most of the time
+Normal. The bottleneck is HDF5 extraction over NFS (~16 min/batch), not GPU cellpose (~2 min/batch). GPU utilization ~15%.
+
+---
+
+## Pipeline Architecture
+
+```
+download_stacks → extract → create_broad_structure → aggregate_broad_batch (×N) → rechunk_broad → aggregate
+```
+
+- **download_stacks**: Downloads .npy stacks from S3 (cellpainting-gallery)
+- **extract**: Runs SPARCSpy + Cellpose segmentation, extracts single cells to H5
+- **create_broad_structure**: Creates directory layout for Broad-format output
+- **aggregate_broad_batch**: Per-batch: reads H5, writes zarr groups (label_image, single_cell_index, single_cell_data)
+- **rechunk_broad**: Recompresses all zarr plates with sharded zarr v3 (zstd, per-cell chunks)
+- **aggregate**: Writes final checkpoint file
+
+Extraction outputs are marked `temp()` — H5 files are deleted after aggregation consumes them.
+
+---
+
+## Running Multiple Sources in Parallel
+
+Each source needs its own GPU node (or at least its own GPU + 15 cores). To run N sources simultaneously:
+
+1. Get N GPU nodes
+2. On each node, `cd` to a different `final_source{NN}/snakemake/`
+3. Run `pixi run run` on each
+
+Sources are completely independent — they don't share state. The only shared resource is the conda env prefix directory, which is read-only after env creation.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -163,6 +163,20 @@ The key insight: **don't trust log file counts** (NFS lag). Count output files o
 
 ---
 
+## aggregate_broad.yml with ome-zarr installs zarr v2, not v3
+
+The `aggregate_broad.yml` conda env spec originally depended on `ome-zarr`, which pulls in zarr 2.x. The updated `aggregate_broad_batch.py` uses `create_array()` which works in both v2 and v3, but `rechunk_broad.py` uses zarr v3-only features (`zarr.codecs.BloscCodec`, `shards=`, `group_keys()`). For consistency, change the dep to `zarr>=3` and drop `ome-zarr`.
+**Why:** Discovered during source06 migration — the shared conda env (hash 425de6b...) had zarr 2.17.0. New env (hash d07e6420...) created with zarr v3.
+
+---
+
+## Per-source deployments diverge from repo main over time
+
+Each `final_sourceNN/snakemake/` checkout drifts: local commits on main, stashed config changes, old branches. Migration pattern: stash → fetch → reset --hard origin/main → pop stash (resolve conflicts keeping main code + source-specific configs). The only files that should differ per-source are `config/samples.json`, `config/sparcspy.yml`, and `profile/config.yaml`.
+**Why:** Found 6 different git states across 11 sources (two branches, two main versions, various local commits). Standardizing all at once prevents subtle differences in pipeline behavior.
+
+---
+
 ## Download .npy files disappearing doesn't mean download failed
 
 The extract rule consumes the .npy but it's not marked `temp()` — however, if the pipeline is killed mid-run and restarted, snakemake may re-download. Missing .npy files with existing download logs means the pipeline was interrupted, not that downloads failed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,27 +15,38 @@
 - [x] Fixed zarr v3 incompatibility in `rechunk_broad.py`: replaced dask `to_zarr()` with native zarr v3 `create_array()` using `shards`/`chunks`/`compressors`; initialized store before workers (PR #11)
 - [x] Added pixi.toml for snakemake 8 (PR #11)
 
+## All-Source Migration (2026-04-10)
+
+- [x] All 11 source deployments migrated to current main (d74cf93) with zarr v3 fixes, pixi.toml, updated scripts
+- [x] All `aggregate_broad.yml` updated: `ome-zarr` (zarr v2) → `zarr>=3`
+- [x] All profiles standardized: 15 cores, vram_mb=80000, mem_mb=300000
+- [x] All diameters standardized: nucleus=23, cytosol=57 (source04 was 25/69, changed for consistency)
+- [x] Source02 samples.json: removed subset filters (Metadata_PlateType, Metadata_InChIKey) — now processes full source_2
+- [x] New zarr v3 conda env created (hash d07e64204b55eb5dcc9dfdcb6fbe5b55)
+
 ## Per-Source Pipeline Status
 
-- [x] sources 02, 08, 10: Fully complete (final aggregate exists).
-- [x] **source04**: Completed 2026-04-08. All 708 batches extracted, 277 plates rechunked, aggregate checkpoint written.
-- [ ] **source03**: 98.6% done (4128/4186 batches extracted). Not currently running — needs restart for last 58 batches, then aggregation.
-- [ ] **source06**: 100% extraction done (3207/3206), 2 broad batches aggregated — needs aggregation pipeline run.
-- [ ] **source13**: 100% extraction done (286/286 batches) — needs aggregation pipeline run.
-- [ ] **source05**: 80.5% done (2896/3595 batches). Not running.
-- [ ] **source09**: 64.7% done (1717/2652 batches). Not running.
-- [ ] **source11**: 73.7% done (1779/2415 batches). Not running.
-- [ ] **source07**: 53.9% done (953/1769 batches). Not running.
+- [ ] **source02**: Migrated. Previously complete but needs aggregation rerun with zarr v3 for consistency.
+- [ ] **source03**: 98.6% extracted (4128/4186). Migrated, not running — needs restart for last 58 batches, then aggregation.
+- [ ] **source04**: Migrated. **Needs full rerun** — diameters changed from 25/69 to 23/57, all prior extraction/segmentation is invalid.
+- [ ] **source05**: 80.5% extracted (2896/3595). Migrated, not running.
+- [ ] **source06**: 100% extracted (3207). Aggregation pipeline running as of 2026-04-10 ~22:00. Currently in create_broad_structure phase.
+- [ ] **source07**: 53.9% extracted (953/1769). Migrated, not running.
+- [ ] **source08**: Migrated. Previously complete but needs aggregation rerun with zarr v3 for consistency.
+- [ ] **source09**: 64.7% extracted (1717/2652). Migrated, not running.
+- [ ] **source10**: Migrated. Previously complete but needs aggregation rerun with zarr v3 for consistency.
+- [ ] **source11**: 73.7% extracted (1779/2415). Migrated, not running.
+- [ ] **source13**: 100% extracted (286), 93 segmentations. Migrated, not running — needs pipeline run.
 - [ ] Kick off remaining sources on separate nodes
 
-## Source 04 Completed Items
+## Source 04 Completed Items (prior run — now invalidated by diameter change)
 
 - [x] Diagnosed why source_4 only had 244/708 batches: May 2025 re-run was killed mid-execution
 - [x] Installed snakemake 8 via pixi, created pixi.toml, updated profile (15 cores, 80GB VRAM, 300GB RAM)
 - [x] Pipeline completed successfully (2026-04-08 19:22) — all 277 plates rechunked
-- [ ] Verify rechunked compressed output integrity (spot-check a few plates)
+- [x] ~~Verify rechunked compressed output integrity~~ — moot, full rerun needed (diameters changed 25/69 → 23/57)
+- [ ] Clean up old source04 results before rerun (extraction, segmentation, aggregated dirs contain data from old diameters)
 - [ ] Clean up leftover temp mmap dirs in source04 `results/tmp/` (40 dirs from May 2025)
-- [ ] Clean up duplicate log files from failed launch attempts
 
 ## Performance
 
@@ -46,14 +57,16 @@
 
 ## Downstream
 
-- [ ] Replicate zarr v3 fixes to other source pipelines if they use older scripts
-- [ ] Verify rechunk_broad Zarr v3 output is correct before running on all sources
+- [x] ~~Replicate zarr v3 fixes to other source pipelines~~ — all 11 sources migrated to current main (2026-04-10)
+- [ ] Verify rechunk_broad Zarr v3 output is correct (check source06 output once aggregation finishes)
 - [ ] Final aggregate step for all sources still pending
+- [ ] Rerun aggregation for sources 02, 08, 10 with zarr v3 for output consistency
 
-## Config Notes (source_4-specific, NOT committed to main)
-- `samples.json`: `{"samples": [{"Metadata_Source": "source_4"}]}` (708 batches)
-- `sparcspy.yml`: nucleus diameter=25, cytosol diameter=69 (differs from repo default of 21/53)
-- `profile/config.yaml`: 15 cores, vram_mb=80000, mem_mb=300000
+## Config Notes (all sources, NOT committed — local overrides in each deployment)
+- `samples.json`: `{"samples": [{"Metadata_Source": "source_N"}]}` per source
+- `sparcspy.yml`: nucleus diameter=23, cytosol diameter=57 (all sources standardized)
+- `profile/config.yaml`: 15 cores, vram_mb=80000, mem_mb=300000 (all sources standardized)
+- `aggregate_broad.yml`: zarr>=3 (all sources, replaces ome-zarr/zarr v2)
 
 ## Known Issues
 - Extract rule outputs are marked `temp()` — extraction/segmentation H5 files get deleted after downstream rules consume them


### PR DESCRIPTION
## Summary
- Update `aggregate_broad.yml` to use `zarr>=3` instead of `ome-zarr` (which pulled in zarr v2)
- Update task tracking: all 11 source deployments migrated to current main with standardized configs
- Add lessons learned about zarr v2/v3 env mismatch and per-source deployment drift

## Context
All per-source pipeline deployments (`final_source{02..13}`) have been migrated to current main with:
- zarr v3 aggregate env
- Standardized diameters (nucleus=23, cytosol=57)