### PR TITLE
fix(aggregate): idempotent resume + per-image hot-loop cleanup

### DIFF
--- a/snakemake/scripts/aggregate_broad_batch.py
+++ b/snakemake/scripts/aggregate_broad_batch.py
@@ -3,7 +3,6 @@ import logging
 import pathlib as pl
 
 import h5py
-import numpy as np
 import zarr
 
 module_logger = logging.getLogger(__name__)
@@ -16,7 +15,7 @@ class StatusError(Exception):
 
 
 def _aggregate(
-        extraction_path: str, segmentation_path: str, source: str, output: str, debug: bool = False
+        extraction_path: str, segmentation_path: str, source: str, output: str
 ) -> None:
     module_logger.info(f"Aggregating plates for {source}")
     channel_mapping = {
@@ -30,27 +29,28 @@ def _aggregate(
     }
     module_logger.info(f"Channel mapping: {channel_mapping}")
 
-    # extraction_paths = [pl.Path(extraction_batch) for extraction_batch in extraction_batches]
-    # segmentation_paths = [pl.Path(segmentation_batch) for segmentation_batch in segmentation_batches]
-
     output_base = pl.Path(output).joinpath("cellpose/objects")
     if not output_base.exists():
         msg = f"Output base directory ({output_base}) does not exist, aborting"
         module_logger.error(msg)
         raise FileNotFoundError(msg)
-    # output_base.mkdir(parents=True, exist_ok=True)
 
-    # for extraction_path, segmentation_path in zip(extraction_paths, segmentation_paths):
-    # module_logger.info(f"Processing snakemake batch {extraction_path.parent.name}")
     with (
         h5py.File(segmentation_path, "r") as segmentation_file,
         h5py.File(extraction_path, mode="r") as extraction_file,
     ):
+        cell_indices_by_image: dict[bytes, list[int]] = {}
+        for row_idx, img_id in enumerate(extraction_file["single_cell_index_labelled"][:, 2]):
+            cell_indices_by_image.setdefault(img_id, []).append(row_idx)
+
+        zarr_groups: dict[str, zarr.Group] = {}
+        mapping_written: set[pl.Path] = set()
+
         n_images = segmentation_file["labels"].shape[0]
         for image_idx in range(n_images):
             image_id = segmentation_file["labels"][image_idx, 1].decode()
             module_logger.info(f"Processing image {image_id}")
-            source, batch, plate, well, spot = tuple(image_id.split("__"))
+            _, batch, plate, _, _ = image_id.split("__")
 
             output_path = output_base.joinpath(batch, plate, f"{plate}.zarr")
             if not output_path.parent.exists():
@@ -59,15 +59,24 @@ def _aggregate(
                 module_logger.error(msg)
                 raise FileNotFoundError(msg)
 
-            with output_path.parent.joinpath("channel_mapping.json").open("w") as mapping_file:
-                json.dump(obj=channel_mapping, fp=mapping_file)
+            if output_path.parent not in mapping_written:
+                with output_path.parent.joinpath("channel_mapping.json").open("w") as mapping_file:
+                    json.dump(obj=channel_mapping, fp=mapping_file)
+                mapping_written.add(output_path.parent)
 
-            cell_indices = np.where(extraction_file["single_cell_index_labelled"][:, 2] == image_id.encode())[
-                0
-            ].tolist()
+            cell_indices = cell_indices_by_image.get(image_id.encode(), [])
 
-            out_zarr = zarr.open(str(output_path.resolve()), mode="a")
-            image_group = out_zarr.create_group(image_id, overwrite=debug)
+            store_key = str(output_path.resolve())
+            if store_key not in zarr_groups:
+                zarr_groups[store_key] = zarr.open(store_key, mode="a")
+            out_zarr = zarr_groups[store_key]
+
+            # overwrite=True makes resume after a TIMEOUT'd SLURM job idempotent: any
+            # partial group left from a prior interrupted run gets wiped and rewritten
+            # rather than raising ContainsGroupError. Each (plate, well, site) is
+            # assigned to exactly one batch by design, so no concurrent writer can
+            # collide on the same image_id.
+            image_group = out_zarr.create_group(image_id, overwrite=True)
             image_group.create_array(name="label_image", data=segmentation_file["segmentation"][image_idx])
             image_group.create_array(name="single_cell_index", data=extraction_file["single_cell_index"][cell_indices])
             image_group.create_array(name="single_cell_data", data=extraction_file["single_cell_data"][cell_indices])


### PR DESCRIPTION
## Summary

- Fix `aggregate_broad_batch` so a TIMEOUT'd SLURM job's partial zarr state doesn't poison the next run with `ContainsGroupError`.
- Drop three per-image-call overheads inside the 250-iteration hot loop.

## Why

Today the per-batch script writes zarr groups for each image, then writes the snakemake ckpt file at the very end. When a SLURM job hits the 24h `gpu_normal` walltime cap mid-batch, some image groups are on disk but the ckpt is not. On resume, snakemake correctly retries those batches, but `create_group(image_id, overwrite=False)` then collides with the leftover partial groups and raises `ContainsGroupError`. With retries exhausted, snakemake aborts the run — and the next 24h resume hits the same wall.

This is what was killing sources 06/07/08 within minutes of every recent resubmit; the failures look like simultaneous NFS drops because ~15 in-flight batches all hit the error at the same moment, but the actual exception (visible in the snakemake supervisor log, not the per-batch logs) is `zarr.errors.ContainsGroupError`. Confirmed by observing that `source_11` ran cleanly on the same `gpusrv61` node where `source_07` died at minute 21 with this error.

`overwrite=True` makes a retried batch idempotent. By the metadata batching design, every `(plate, well, site)` lives in exactly one snakemake batch, so no concurrent writer can collide on the same `image_id`.

## What else changed

Inside the hot loop (run N=250 times per batch), three things were paid per image when they only needed to be paid once:

| change | was | now |
|---|---|---|
| `channel_mapping.json` | rewritten on every iteration | written once per plate dir per batch |
| `cell_indices` lookup | `np.where(...)` linear scan → O(images × cells) | dict[image_id → row_indices], built once |
| `zarr.open(...)` | called per image, each does an NFS metadata read | cached per store path within the batch |

Removed the unused `debug` parameter (only ever read by the `overwrite` flag) and a few stale comments. Dropped the `numpy` import since `np.where` was its only use.

## Test plan

- [ ] Apply the same diff into one source's local snakemake checkout (e.g. source06) and resubmit. Verify aggregate batches run to completion past the previous failure point.
- [ ] Verify per-batch wallclock has dropped from the ~3.5–5 min baseline.
- [ ] Smoke-test resume behavior: kill a running source mid-aggregate, restart, confirm partial groups are overwritten cleanly without `ContainsGroupError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)