### PR TITLE
fix: handle batches where sparcspy filters out all cells

### DIFF
--- a/snakemake/scripts/extract.py
+++ b/snakemake/scripts/extract.py
@@ -2,9 +2,51 @@ import logging
 import pathlib as pl
 import shutil
 
+import h5py
 import numpy as np
 import pandas as pd
 from sparcscore.pipeline import extraction, project, workflows
+
+
+def _count_segmented_cells(project_dir: str) -> int:
+    """Return number of cells that survived sparcspy's post-segmentation filter.
+
+    Returns -1 if classes.csv is missing — callers should treat this as
+    "unknown" and run the normal extract path so any real failure surfaces.
+    """
+    classes_csv = pl.Path(project_dir) / "segmentation" / "classes.csv"
+    if not classes_csv.exists():
+        return -1
+    if classes_csv.stat().st_size == 0:
+        return 0
+    with classes_csv.open() as f:
+        return sum(1 for _ in f)
+
+
+def _write_empty_extraction_h5(target_path: pl.Path) -> None:
+    """Write a schema-valid extraction h5 with zero rows.
+
+    Why: when sparcspy's nucleus/cytosol pairing rejects every cell in a batch,
+    sparcs_project.extract() crashes inside h5py with
+    `IndexError: Index (0) out of range for empty dimension`, killing the whole
+    snakemake DAG. Mirroring the schema with 0-row datasets lets
+    aggregate_broad_batch.py iterate to zero per-image cells and move on.
+    """
+    label_names = [
+        b"index", b"cellid", b"id", b"snakemake_batch",
+        b"Metadata_Source", b"Metadata_PlateType",
+        b"Metadata_InChIKey", b"Metadata_InChI",
+    ]
+    target_path.parent.mkdir(exist_ok=True, parents=True)
+    vlen_bytes = h5py.special_dtype(vlen=bytes)
+    with h5py.File(target_path, "w") as f:
+        f.create_dataset("label_names", data=np.array(label_names, dtype=object), dtype=vlen_bytes)
+        # No chunks/compression on the empty dataset: chunk shape can't exceed
+        # data shape in any dimension, and lzf+chunks gain nothing on 0 rows.
+        # aggregate_broad_batch reads by row index, so layout doesn't matter.
+        f.create_dataset("single_cell_data", shape=(0, 7, 150, 150), dtype=np.float16)
+        f.create_dataset("single_cell_index", shape=(0, 2), dtype=np.uint64)
+        f.create_dataset("single_cell_index_labelled", shape=(0, 8), dtype=vlen_bytes)
 
 
 def get_metadata(metadata_path, batch: str):
@@ -68,7 +110,19 @@ def extraction_workflow(
 
     sparcs_project.load_input_from_array(np.load(batch_stack), label=metadata, overwrite=True)
     sparcs_project.segment()
-    sparcs_project.extract()
+
+    n_cells = _count_segmented_cells(project_dir)
+    if n_cells == 0:
+        logging.warning(
+            "Batch %s produced 0 segmented cells; writing empty extraction h5 "
+            "instead of running sparcs_project.extract() (which would crash on "
+            "an empty single_cell_data shape).",
+            batch,
+        )
+        empty_target = pl.Path(project_dir) / "extraction" / "data" / "single_cells.h5"
+        _write_empty_extraction_h5(empty_target)
+    else:
+        sparcs_project.extract()
 
 
 def main(snakemake):


### PR DESCRIPTION
## Summary

- When sparcspy's nucleus/cytosol pairing rejects every cell in a batch (`classes.csv` ends up empty), `sparcs_project.extract()` crashed with `IndexError: Index (0) out of range for empty dimension` inside h5py.
- That single batch failure exhausted retries and killed the whole snakemake DAG, taking thousands of healthy batches down with it.
- This PR detects the zero-cell case after `segment()` and writes a schema-valid extraction h5 with 0-row datasets instead of calling `extract()`. The pipeline then moves on.

## Reference incident

`source_5` `batch_840` killed three consecutive 24h SLURM jobs on the same single batch:
- `36471179` (2026-05-18 → 19, ~10h)
- `36495278` (2026-05-19, ~4h)
- `36495279` (2026-05-19, ~4h)

All three failed in `extract` for batch_840 with the same error. The `input_segmentation.h5` was 4.3 GB (cellpose ran fine on all 250 sites) but `classes.csv` was 0 bytes — every nucleus mask failed the cytosol-pairing filter.

## How it works

`extract.py`:
1. After `segment()`, read `{project_dir}/segmentation/classes.csv` and count rows.
2. If 0 rows → write a schema-valid extraction h5 with empty datasets (`single_cell_data` shape `(0, 7, 150, 150)`, `single_cell_index` shape `(0, 2)`, `single_cell_index_labelled` shape `(0, 8)`, plus `label_names`).
3. Otherwise → run `extract()` as before.

`aggregate_broad_batch.py` already handles this case: it reads cells by row-index, so an empty extraction produces per-image zarr groups with `single_cell_data` shape `(0, 7, 150, 150)` and preserved `label_image` segmentation masks.

## Test plan

- [x] Helpers tested in isolation: `_count_segmented_cells` returns 0 on batch_840's empty `classes.csv` and -1 on missing input.
- [x] Empty h5 written has the expected 4 datasets with correct shapes + dtypes.
- [x] `aggregate_broad_batch._aggregate(empty_extraction, real_batch_840_seg, ...)` ran end-to-end: wrote 15 plate zarrs (one per plate touched by batch_840) with the right structure. No errors.
- [x] `snakemake --dryrun` on source_5 confirms the patch doesn't invalidate the 3003 already-extracted batches: only 592 extracts queued (the missing ones, including batch_840), matching the prior plan. `extract` is not in the "outdated metadata" list.

## Blast radius

The rule uses `shell:` (not `script:`), so snakemake doesn't hash this file as a rerun trigger. Existing extractions stay valid; only batches without outputs will run, which is the desired behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)